### PR TITLE
Fix webcam rendering disabling depth test

### DIFF
--- a/src/client/java/com/lichcode/webcam/render/PlayerFaceRenderer.java
+++ b/src/client/java/com/lichcode/webcam/render/PlayerFaceRenderer.java
@@ -91,7 +91,6 @@ public class PlayerFaceRenderer extends FeatureRenderer<PlayerEntityRenderState,
         glEnable(GL_DEPTH_TEST);
         BufferRenderer.drawWithGlobalProgram(buffer.end());
         glUseProgram(0);
-        glDisable(GL_DEPTH_TEST);
         glEnable(GL_CULL_FACE);
         glBindTexture(GL_TEXTURE_2D, 0);
 


### PR DESCRIPTION
## Summary
- ensure depth testing stays enabled after drawing player webcam textures

## Testing
- `./gradlew test` *(fails: plugin not found due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_6856b9cba0108331ac46b92b9eef06fe