### PR TITLE
Optimize HUD rendering

### DIFF
--- a/src/client/java/com/lichcode/webcam/WebcamModClient.java
+++ b/src/client/java/com/lichcode/webcam/WebcamModClient.java
@@ -4,6 +4,8 @@ import com.lichcode.webcam.Video.PlayerVideo;
 import com.lichcode.webcam.Video.PlayerVideoPacketCodec;
 import com.lichcode.webcam.config.WebcamConfig;
 import com.lichcode.webcam.render.PlayerFaceRenderer;
+import com.lichcode.webcam.PlayerFeeds;
+import com.lichcode.webcam.render.image.RenderableImage;
 
 import com.lichcode.webcam.screen.SettingsScreen;
 import com.lichcode.webcam.video.VideoManager;
@@ -18,25 +20,23 @@ import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.entity.PlayerEntityRenderer;
-import net.minecraft.client.texture.NativeImage;
-import net.minecraft.client.texture.NativeImageBackedTexture;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.render.*;
+import org.joml.Matrix4f;
 import net.minecraft.network.PacketByteBuf;
-import net.minecraft.util.Identifier;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.option.KeyBinding;
 import org.lwjgl.glfw.GLFW;
+import static org.lwjgl.opengl.GL33.*;
 
 import static com.lichcode.webcam.WebcamMod.MOD_ID;
 
-import java.nio.ByteBuffer;
 
 
 
 public class WebcamModClient implements ClientModInitializer {
 	public static KeyBinding openWebcamSettingsKey;
 
-	private static NativeImageBackedTexture hudTexture;
-	private static Identifier hudTextureId;
 
 	@Override
 	public void onInitializeClient() {
@@ -86,48 +86,42 @@ public class WebcamModClient implements ClientModInitializer {
 		HudRenderCallback.EVENT.register((DrawContext ctx, float tickDelta) -> {
 			// UUID текущего игрока
 			String selfUuid = MinecraftClient.getInstance().player.getUuidAsString();
-			// вытаскиваем свой видеопоток
-			PlayerVideo myVideo = PlayerFeeds.getPlayerVideo(selfUuid);
+                        // вытаскиваем предварительно подготовленное изображение
+                        RenderableImage image = PlayerFeeds.get(selfUuid);
 
-			if (myVideo != null && myVideo.frame != null) {
-				int w = myVideo.width;
-				int h = myVideo.height;
-				ByteBuffer buf = myVideo.asByteBuffer(); // rgb
+                        if (image != null && image.data() != null) {
+                                image.init();
 
-				// RGB → NativeImage (полный ARGB, alpha=255)
-				NativeImage nativeImg = new NativeImage(w, h, false);
-				for (int y = 0; y < h; y++) {
-					for (int x = 0; x < w; x++) {
-						int r = buf.get() & 0xFF;
-						int g = buf.get() & 0xFF;
-						int b = buf.get() & 0xFF;
-						nativeImg.setColor(x, y, (0xFF << 24) | (r << 16) | (g << 8) | b);
-					}
-				}
+                                glBindTexture(GL_TEXTURE_2D, image.id);
+                                image.buffer.bind();
+                                glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, image.width, image.height, GL_RGB, GL_UNSIGNED_BYTE, 0);
+                                image.buffer.unbind();
+                                image.buffer.writeAndSwap(image.data().duplicate());
+                                glBindTexture(GL_TEXTURE_2D, image.id);
 
-				// (пере)создаём динамическую текстуру, если нужно
-				if (hudTexture == null || hudTexture.getImage().getWidth() != w || hudTexture.getImage().getHeight() != h) {
-					if (hudTextureId != null) {
-						MinecraftClient.getInstance().getTextureManager().destroyTexture(hudTextureId);
-					}
-					hudTexture = new NativeImageBackedTexture(nativeImg);
-					hudTextureId = MinecraftClient.getInstance()
-						.getTextureManager()
-						.registerDynamicTexture("webcam_hud", hudTexture);
-				} else {
-					hudTexture.setImage(nativeImg);
-					hudTexture.upload();
-				}
+                                int size = 32;
+                                int xPos = MinecraftClient.getInstance().getWindow().getScaledWidth() - size - 8;
+                                int yPos = 8;
 
-				// рисуем превью 64×64 в правом верхнем углу
-				int size = 32;
-				int xPos = MinecraftClient.getInstance().getWindow().getScaledWidth() - size - 8;
-				int yPos = 8;
+                                Matrix4f matrix = ctx.getMatrices().peek().getPositionMatrix();
+                                Tessellator tessellator = Tessellator.getInstance();
+                                BufferBuilder buffer = tessellator.getBuffer();
+                                buffer.begin(VertexFormat.DrawMode.TRIANGLE_STRIP, VertexFormats.POSITION_TEXTURE);
+                                buffer.vertex(matrix, xPos, yPos + size, 0).texture(0, 1).next();
+                                buffer.vertex(matrix, xPos, yPos, 0).texture(0, 0).next();
+                                buffer.vertex(matrix, xPos + size, yPos + size, 0).texture(1, 1).next();
+                                buffer.vertex(matrix, xPos + size, yPos, 0).texture(1, 0).next();
 
-				ctx.drawTexture(hudTextureId, xPos, yPos, 0, 0, size, size, size, size);
-			}
-		});
-	}
+                                RenderSystem.setShader(GameRenderer::getPositionTexProgram);
+                                RenderSystem.setShaderColor(1, 1, 1, 1);
+                                RenderSystem.setShaderTexture(0, image.id);
+                                glDisable(GL_CULL_FACE);
+                                tessellator.draw();
+                                glEnable(GL_CULL_FACE);
+                                glBindTexture(GL_TEXTURE_2D, 0);
+                        }
+                });
+        }
 
 
 	private void registerSettingsCommand() {


### PR DESCRIPTION
## Summary
- reuse player's RenderableImage to draw webcam preview in HUD
- remove unnecessary dynamic texture allocation

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6856c3e943608331ac884d8298936e3e